### PR TITLE
🔀 [Feature] ApiResponse와 ErrorCode로 공통 응답 포맷 구현

### DIFF
--- a/src/main/java/com/mycom/springsandbox/common/enums/ErrorCode.java
+++ b/src/main/java/com/mycom/springsandbox/common/enums/ErrorCode.java
@@ -1,0 +1,36 @@
+package com.mycom.springsandbox.common.enums;
+
+import org.springframework.http.HttpStatus;
+
+public enum ErrorCode {
+
+    // 사용자 관련(1000 ~ 1999)
+    USER_NOT_FOUND(1001, "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_CREDENTIALS(1002, "아이디 또는 비밀번호가 올바르지 않습니다.", HttpStatus.UNAUTHORIZED),
+
+    // 인증/인가(2000~2999)
+    TOKEN_EXPIRED(2001, "토큰이 만료되었습니다.", HttpStatus.UNAUTHORIZED),
+    ACCESS_DENIED(2002, "접근 권한이 없습니다.", HttpStatus.FORBIDDEN);
+
+    private final int code;
+    private final String defaultMessage;
+    private final HttpStatus httpStatus;
+
+    ErrorCode(int code, String defaultMessage, HttpStatus httpStatus) {
+        this.code = code;
+        this.defaultMessage = defaultMessage;
+        this.httpStatus = httpStatus;
+    }
+
+    public int getCode() {
+        return code;
+    }
+
+    public String getDefaultMessage() {
+        return defaultMessage;
+    }
+
+    public HttpStatus getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/mycom/springsandbox/common/enums/ErrorCode.java
+++ b/src/main/java/com/mycom/springsandbox/common/enums/ErrorCode.java
@@ -1,7 +1,9 @@
 package com.mycom.springsandbox.common.enums;
 
+import lombok.Getter;
 import org.springframework.http.HttpStatus;
 
+@Getter
 public enum ErrorCode {
 
     // 사용자 관련(1000 ~ 1999)
@@ -20,17 +22,5 @@ public enum ErrorCode {
         this.code = code;
         this.defaultMessage = defaultMessage;
         this.httpStatus = httpStatus;
-    }
-
-    public int getCode() {
-        return code;
-    }
-
-    public String getDefaultMessage() {
-        return defaultMessage;
-    }
-
-    public HttpStatus getHttpStatus() {
-        return httpStatus;
     }
 }

--- a/src/main/java/com/mycom/springsandbox/common/response/ApiResponse.java
+++ b/src/main/java/com/mycom/springsandbox/common/response/ApiResponse.java
@@ -67,7 +67,7 @@ public record ApiResponse<T>(
                 .errorCode(ec.getCode())
                 .message(ec.getDefaultMessage())
                 .data(data)
-                .timestamp(now())
+                .timestamp(getCurrentTimestamp())
                 .build();
     }
 }

--- a/src/main/java/com/mycom/springsandbox/common/response/ApiResponse.java
+++ b/src/main/java/com/mycom/springsandbox/common/response/ApiResponse.java
@@ -1,0 +1,73 @@
+package com.mycom.springsandbox.common.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.mycom.springsandbox.common.enums.ErrorCode;
+import lombok.Builder;
+
+import java.time.LocalDateTime;
+import java.util.Objects;
+
+import static java.time.LocalDateTime.now;
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public record ApiResponse<T>(
+        boolean success,
+        Integer errorCode,
+        String message,
+        T data,
+        @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+        LocalDateTime timestamp
+) {
+    @Builder
+    public  ApiResponse {
+    }
+
+    private static LocalDateTime getCurrentTimestamp() {
+        return now();
+    }
+
+    // 성공 응답만 알릴 때
+    public static <T> ApiResponse<T> success(String message) {
+        Objects.requireNonNull(message, "메시지는 null일 수 없습니다.");
+        return ApiResponse.<T>builder()
+                .success(true)
+                .message(message)
+                .timestamp(getCurrentTimestamp())
+                .build();
+    }
+
+    // 데이터와 함께 성공 응답
+    public static <T> ApiResponse<T> success(String message, T data) {
+        Objects.requireNonNull(message, "메시지는 null일 수 없습니다.");
+        return ApiResponse.<T>builder()
+                .success(true)
+                .message(message)
+                .data(data)
+                .timestamp(getCurrentTimestamp())
+                .build();
+    }
+
+    // 에러만 알릴 때
+    public static <T> ApiResponse<T> error(ErrorCode ec) {
+        Objects.requireNonNull(ec, "메시지는 null일 수 없습니다.");
+        return ApiResponse.<T>builder()
+                .success(false)
+                .errorCode(ec.getCode())
+                .message(ec.getDefaultMessage())
+                .timestamp(getCurrentTimestamp())
+                .build();
+    }
+
+    // 에러 + 추가 데이터
+    public static <T> ApiResponse<T> error(ErrorCode ec, T data) {
+        Objects.requireNonNull(ec);
+        return ApiResponse.<T>builder()
+                .success(false)
+                .errorCode(ec.getCode())
+                .message(ec.getDefaultMessage())
+                .data(data)
+                .timestamp(now())
+                .build();
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
#10 ApiResponse

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->
- `common.response` 패키지에 `ApiResponse<T>` record 정의  
  - `success`, `errorCode`, `message`, `data`, `timestamp` 필드 포함  
  - Lombok `@Builder` + Jackson 어노테이션으로 직렬화 설정  
- `common.enums` 패키지에 `ErrorCode` enum 추가  
  - 비즈니스 오류 코드와 기본 메시지, `HttpStatus` 매핑  
- `GlobalExceptionHandler`에서 `ErrorCode` 기반 에러 응답 처리  
- 기존 컨트롤러를 `ResponseEntity<ApiResponse<?>>` 구조로 리팩토링

## :camera_with_flash: 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 --> 
