### PR TITLE
[Feature] 사용자 도메인 설계

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -27,7 +27,6 @@ dependencies {
     // 1. 웹 애플리케이션
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
-    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // 2. 컴파일 시점 전용 (Lombok)
     compileOnly 'org.projectlombok:lombok'
@@ -40,7 +39,7 @@ dependencies {
 
     // 5. 테스트
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
-    testRuntimeOnly  'org.junit.platform:junit-platform-launcher'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 
 tasks.named('test') {

--- a/build.gradle
+++ b/build.gradle
@@ -27,6 +27,7 @@ dependencies {
     // 1. 웹 애플리케이션
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 
     // 2. 컴파일 시점 전용 (Lombok)
     compileOnly 'org.projectlombok:lombok'

--- a/docs/common/v1/policy/BRANCH_STRATEGY.md
+++ b/docs/common/v1/policy/BRANCH_STRATEGY.md
@@ -1,4 +1,4 @@
-# Branching Strategy (Gitflow + Jira)
+# Branching Strategy (Gitflow)
 ## 1. 기본 브랜치
 | 브랜치 | 역할 |
 |------|------|
@@ -6,18 +6,18 @@
 | dev | 개발 통합 브랜치. 모든 기능 브랜치의 머지 대상 |
 
 ## 2. 브랜치 타입 (Prefix)
-모든 작업 브랜치는 Jira 티켓 키를 포함한다.
+모든 작업 브랜치는 Github Issude Number를 기준으로 합니다.
 
 형식:
 ```
-<prefix>/<jira-key>-<short-description>
+<prefix>/<issueNumber>-<short-description>
 ```
 
 예:
 ```
-feature/ANS-123-login-api
-refactor/ANS-245-auth-service-cleanup
-chore/ANS-310-update-gradle
+feature/123-login-api
+refactor/245-auth-service-cleanup
+chore/10-update-gradle
 ```
 
 ### Prefix 종류
@@ -35,7 +35,7 @@ chore/ANS-310-update-gradle
 1. dev 브랜치에서 작업 브랜치 생성
 ```
 git checkout dev
-git checkout -b feature/ANS-123-login-api
+git checkout -b feature/123-login-api
 ```
 2. 개발 및 커밋
 3. dev 대상으로 Pull Request 생성
@@ -75,7 +75,7 @@ git push origin v1.2.0
 
 형식:
 ```
-hotfix/<jira-key>-<short-description>
+hotfix/<issueNumber>-<short-description>
 ```
 
 사용 기준:
@@ -88,7 +88,7 @@ hotfix/<jira-key>-<short-description>
 1. main 브랜치에서 hotfix 브랜치 생성
 ```
 git checkout main
-git checkout -b hotfix/ANS-999-payment-null-pointer
+git checkout -b hotfix/999-payment-null-pointer
 ```
 2. 수정 및 커밋
 3. main 브랜치로 머지
@@ -101,7 +101,7 @@ git push origin v1.2.1
 
 ## 6. Pull Request 규칙
 
-- 모든 PR은 Jira 티켓 키 포함
+- 모든 PR은 Github Issue 포함
 - PR 제목 형식:
 ```
 [ANS-123] Login API 구현
@@ -131,4 +131,3 @@ v1.2.3
 ## 9. 금지 사항
 - main 브랜치 직접 커밋 금지
 - dev 브랜치 직접 커밋 금지
-- Jira 티켓 없는 브랜치 생성 금지

--- a/src/main/java/com/mycom/springsandbox/user/domain/entity/Follow.java
+++ b/src/main/java/com/mycom/springsandbox/user/domain/entity/Follow.java
@@ -1,0 +1,57 @@
+package com.mycom.springsandbox.user.domain.entity;
+
+import java.util.Objects;
+
+public class Follow {
+
+    private final User follower;
+    private final User following;
+
+    public Follow(User follower, User following) {
+
+        if (follower == null) {
+            throw new IllegalArgumentException("팔로우 요청자는 필수입니다.");
+        }
+
+        if (following == null) {
+            throw new IllegalArgumentException("팔로우 대상자는 필수입니다.");
+        }
+
+        if (follower.isSameUser(following)) {
+            throw new IllegalArgumentException("자기 자신은 팔로우할 수 없습니다.");
+        }
+
+        this.follower = follower;
+        this.following = following;
+    }
+
+    public void apply() {
+        follower.increaseFollowingCount();
+        following.increaseFollowerCount();
+    }
+
+    public void cancel() {
+        follower.decreaseFollowingCount();
+        following.decreaseFollowerCount();
+    }
+
+    public boolean isSameRelation(User follower, User following) {
+        return this.follower.isSameUser(follower)
+                && this.following.isSameUser(following);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        Follow follow = (Follow) o;
+        return Objects.equals(follower, follow.follower)
+                && Objects.equals(following, follow.following);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(follower, following);
+    }
+}

--- a/src/main/java/com/mycom/springsandbox/user/domain/entity/User.java
+++ b/src/main/java/com/mycom/springsandbox/user/domain/entity/User.java
@@ -1,8 +1,5 @@
 package com.mycom.springsandbox.user.domain.entity;
-
-import com.mycom.springsandbox.user.domain.type.UserRole;
-import com.mycom.springsandbox.user.domain.type.UserStatus;
-
+import com.mycom.springsandbox.user.domain.vo.UserInfo;
 import java.util.Objects;
 
 public class User {
@@ -10,22 +7,13 @@ public class User {
     private final long id; // 내부 식별자
     private final String userCode; //외부 공개 식별자
 
-    // 필수 속성
-    private String loginId; // 사용자가 입력하는 로그인 아이디
-    private String username; // 사용자가 입력하는 사용자명
-    private String email;
-    private String phoneNumber;
-    private String password;
+    private UserInfo userInfo;
 
-    private UserRole userRole;
-    private UserStatus userStatus;
+    public User(long id, String userCode, UserInfo userInfo) {
 
-    // 선택 속성
-    private String ProfileImageUrl;
-
-    public User(long id, String userCode) {
         this.id = id;
         this.userCode = userCode;
+        this.userInfo = userInfo;
     }
 
 

--- a/src/main/java/com/mycom/springsandbox/user/domain/entity/User.java
+++ b/src/main/java/com/mycom/springsandbox/user/domain/entity/User.java
@@ -11,7 +11,8 @@ public class User {
     private final String userCode; //외부 공개 식별자
 
     // 필수 속성
-    private String username;
+    private String loginId; // 사용자가 입력하는 로그인 아이디
+    private String username; // 사용자가 입력하는 사용자명
     private String email;
     private String phoneNumber;
     private String password;
@@ -30,9 +31,10 @@ public class User {
 
     @Override
     public boolean equals(Object o) {
+        if(this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         User user = (User) o;
-        return userCode == user.userCode;
+        return Objects.equals(userCode, user.userCode);
     }
 
     @Override

--- a/src/main/java/com/mycom/springsandbox/user/domain/entity/User.java
+++ b/src/main/java/com/mycom/springsandbox/user/domain/entity/User.java
@@ -1,0 +1,44 @@
+package com.mycom.springsandbox.user.domain.entity;
+
+import com.mycom.springsandbox.user.domain.type.UserRole;
+import com.mycom.springsandbox.user.domain.type.UserStatus;
+
+import java.util.Objects;
+
+public class User {
+
+    private final long id; // 내부 식별자
+    private final String userCode; //외부 공개 식별자
+
+    // 필수 속성
+    private String username;
+    private String email;
+    private String phoneNumber;
+    private String password;
+
+    private UserRole userRole;
+    private UserStatus userStatus;
+
+    // 선택 속성
+    private String ProfileImageUrl;
+
+    public User(long id, String userCode) {
+        this.id = id;
+        this.userCode = userCode;
+    }
+
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        User user = (User) o;
+        return userCode == user.userCode;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(userCode);
+    }
+
+
+}

--- a/src/main/java/com/mycom/springsandbox/user/domain/entity/User.java
+++ b/src/main/java/com/mycom/springsandbox/user/domain/entity/User.java
@@ -1,5 +1,7 @@
 package com.mycom.springsandbox.user.domain.entity;
 import com.mycom.springsandbox.user.domain.vo.UserInfo;
+import com.mycom.springsandbox.user.domain.vo.UserRelationCounter;
+
 import java.util.Objects;
 
 public class User {
@@ -9,13 +11,41 @@ public class User {
 
     private UserInfo userInfo;
 
-    public User(long id, String userCode, UserInfo userInfo) {
+    private final UserRelationCounter followerCounter;
+    private final UserRelationCounter followingCounter;
+
+    public User(long id, String userCode, UserInfo userInfo, UserRelationCounter followerCounter, UserRelationCounter followingCounter) {
 
         this.id = id;
         this.userCode = userCode;
         this.userInfo = userInfo;
+        this.followerCounter = followerCounter;
+        this.followingCounter = followingCounter;
     }
 
+    public void increaseFollowerCount() {
+        this.followerCounter.increase();
+    }
+
+    public void decreaseFollowerCount() {
+        this.followerCounter.decrease();
+    }
+
+    public void increaseFollowingCount() {
+        this.followingCounter.increase();
+    }
+
+    public void decreaseFollowingCount() {
+        this.followingCounter.decrease();
+    }
+
+    public boolean isSameUser(User other) {
+        if (other == null) {
+            return false;
+        }
+
+        return Objects.equals(this.userCode, other.userCode);
+    }
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/com/mycom/springsandbox/user/domain/vo/UserInfo.java
+++ b/src/main/java/com/mycom/springsandbox/user/domain/vo/UserInfo.java
@@ -1,0 +1,16 @@
+package com.mycom.springsandbox.user.domain.vo;
+
+public class UserInfo {
+
+    private final String username;
+    private final String profileImageUrl;
+
+    public UserInfo(String username, String profileImageUrl) {
+        if(username == null || username.isBlank()){
+            throw new IllegalArgumentException("사용자명은 필수입니다.");
+        }
+
+        this.username = username;
+        this.profileImageUrl = profileImageUrl;
+    }
+}

--- a/src/main/java/com/mycom/springsandbox/user/domain/vo/UserRelationCounter.java
+++ b/src/main/java/com/mycom/springsandbox/user/domain/vo/UserRelationCounter.java
@@ -1,0 +1,30 @@
+package com.mycom.springsandbox.user.domain.vo;
+
+public class UserRelationCounter {
+
+    private int count;
+
+    public UserRelationCounter(){
+        this(0);
+    }
+
+    public UserRelationCounter(int count){
+        if(count < 0){
+            throw new IllegalArgumentException("팔로우 수는 0보다 작을 수 없습니다.");
+        }
+
+        this.count = count;
+    }
+
+    public void increase(){
+        this.count++;
+    }
+
+    public void decrease(){
+        if(this.count <= 0 ){
+            throw new IllegalArgumentException("팔로우 수는 0보다 작을 수 없습니다.");
+        }
+        this.count--;
+    }
+
+}


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요.
  해당 pull request merge와 함께 이슈를 닫으려면
  closed #Issue_number를 적어주세요 -->
- #25 

## ✨ 과제 내용
<!-- 과제에 대한 설명을 적어주세요 -->

사용자 도메인의 책임 범위와 기본 모델을 정의했습니다.

이번 작업에서는 회원가입/로그인 API 구현이 아니라, 커뮤니티 피드와 프로필 기능에서 사용할 수 있는 
**사용자 도메인의 기준 모델**을 우선 정리했습니다.

### 주요 작업

- `User` 도메인 추가
  - 내부 식별자 `id`
  - 외부 공개 식별자 `userCode`
  - 사용자 기본 정보 `UserInfo`

- `UserInfo` 값 객체 추가
  - `username`
  - `profileImageUrl`
  - `username` 빈 값 검증

- `Follow` 도메인 추가
  - 팔로우 요청자 `follower`
  - 팔로우 대상자 `following`
  - 자기 자신 팔로우 방지
  - 팔로우 적용/취소 처리

- `UserRelationCounter` 값 객체 추가
  - 팔로워/팔로잉 수 관리
  - 카운트가 0 미만이 되지 않도록 제한

### 제외 범위

다음 내용은 별도 이슈에서 다룹니다.

- 회원가입 API
- 로그인 API
- 이메일/전화번호/비밀번호 관리
- JWT/Spring Security
- 커뮤니티 게시글/댓글/좋아요 구현
- 학원 소속 및 실명 관리

## :camera_with_flash: 스크린샷(선택)
<!-- 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요 -->

## 📚 레퍼런스 (또는 새로 알게 된 내용) 혹은 궁금한 사항들
<!-- 참고할 사항이 있다면 적어주세요 --> 
- [객체지향 생활체조 원칙](https://catsbi.oopy.io/bf003ff6-2912-4714-8ac2-44eeb7becc93)
